### PR TITLE
specify remote deploy branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: dokku/github-action@v1
         if:
         with:
+          branch: main
           git_remote_url: 'ssh://${{ vars.DOKKU_HOST }}/${{ vars.DOKKU_APP_NAME }}'
           ssh_host_key: ${{ secrets.DOKKU_SSH_HOST_KEY }}
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}

--- a/.github/workflows/trunk.yaml
+++ b/.github/workflows/trunk.yaml
@@ -91,6 +91,7 @@ jobs:
         uses: dokku/github-action@v1
         if:
         with:
+          branch: main
           git_remote_url: 'ssh://${{ vars.DOKKU_HOST }}/${{ vars.DOKKU_APP_NAME }}'
           ssh_host_key: ${{ secrets.DOKKU_SSH_HOST_KEY }}
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
- Ensure that we are tracking `main` instead of `master` in deploy registries